### PR TITLE
Add Twitter sharing metadata

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -47,4 +47,7 @@
     {{ $title = .Site.Title }}
   {{ end }}
   <title>{{ $title }}</title>
+
+  {{ template "_internal/twitter_cards.html" . }}
+  <meta name="twitter:card" content="summary" />
 </head>


### PR DESCRIPTION
We can utilise Hugo's built-in Twitter card template to render
sharing metadata for Twitter (and Slack, and others that read it) to
make sharing posts better.

However, the default card layout is `summary_large_image` which doesn't
look amazing, so we can overwrite it as a regular `summary`.